### PR TITLE
ci.yaml uses: actions/cache@v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
Curious. Why did "cache@v2" persist even though Sila tied to change it to v3?